### PR TITLE
chore: eliminate virtual camera shadow warnings

### DIFF
--- a/src/VirtualCamera/src/MediaSource.cpp
+++ b/src/VirtualCamera/src/MediaSource.cpp
@@ -354,12 +354,13 @@ HRESULT MediaStream::GetEvent(DWORD flags, IMFMediaEvent** event) {
 }
 
 HRESULT MediaStream::QueueEvent(MediaEventType type, REFGUID extended_type,
-                                HRESULT status, const PROPVARIANT* value) {
+                                HRESULT status,
+                                const PROPVARIANT* event_value) {
     ComPtr<IMFMediaEventQueue> queue;
     HRESULT hr = copy_event_queue(mutex_, event_queue_, queue);
     return FAILED(hr) ? hr
                       : queue->QueueEventParamVar(type, extended_type, status,
-                                                 value);
+                                                 event_value);
 }
 
 HRESULT MediaStream::GetMediaSource(IMFMediaSource** source) {
@@ -727,12 +728,13 @@ HRESULT MediaSource::GetEvent(DWORD flags, IMFMediaEvent** event) {
 }
 
 HRESULT MediaSource::QueueEvent(MediaEventType type, REFGUID extended_type,
-                                HRESULT status, const PROPVARIANT* value) {
+                                HRESULT status,
+                                const PROPVARIANT* event_value) {
     ComPtr<IMFMediaEventQueue> queue;
     HRESULT hr = copy_event_queue(mutex_, event_queue_, queue);
     return FAILED(hr) ? hr
                       : queue->QueueEventParamVar(type, extended_type, status,
-                                                 value);
+                                                 event_value);
 }
 
 HRESULT MediaSource::GetCharacteristics(DWORD* characteristics) {

--- a/src/VirtualCamera/src/MediaSource.h
+++ b/src/VirtualCamera/src/MediaSource.h
@@ -44,7 +44,7 @@ public:
     IFACEMETHODIMP GetEvent(DWORD flags, IMFMediaEvent** event) override;
     IFACEMETHODIMP QueueEvent(MediaEventType type, REFGUID extended_type,
                              HRESULT status,
-                             const PROPVARIANT* value) override;
+                             const PROPVARIANT* event_value) override;
 
     IFACEMETHODIMP GetMediaSource(IMFMediaSource** source) override;
     IFACEMETHODIMP GetStreamDescriptor(IMFStreamDescriptor** descriptor) override;
@@ -106,7 +106,7 @@ public:
     IFACEMETHODIMP GetEvent(DWORD flags, IMFMediaEvent** event) override;
     IFACEMETHODIMP QueueEvent(MediaEventType type, REFGUID extended_type,
                              HRESULT status,
-                             const PROPVARIANT* value) override;
+                             const PROPVARIANT* event_value) override;
 
     IFACEMETHODIMP GetCharacteristics(DWORD* characteristics) override;
     IFACEMETHODIMP CreatePresentationDescriptor(

--- a/src/VirtualCamera/src/MediaSourceActivate.cpp
+++ b/src/VirtualCamera/src/MediaSourceActivate.cpp
@@ -34,17 +34,17 @@ HRESULT MediaSourceActivate::DetachObject() {
     return S_OK;
 }
 
-HRESULT MediaSourceActivate::GetItem(REFGUID key, PROPVARIANT* value) {
-    return attributes_->GetItem(key, value);
+HRESULT MediaSourceActivate::GetItem(REFGUID key, PROPVARIANT* result) {
+    return attributes_->GetItem(key, result);
 }
 
 HRESULT MediaSourceActivate::GetItemType(REFGUID key, MF_ATTRIBUTE_TYPE* type) {
     return attributes_->GetItemType(key, type);
 }
 
-HRESULT MediaSourceActivate::CompareItem(REFGUID key, REFPROPVARIANT value,
+HRESULT MediaSourceActivate::CompareItem(REFGUID key, REFPROPVARIANT item,
                                          BOOL* result) {
-    return attributes_->CompareItem(key, value, result);
+    return attributes_->CompareItem(key, item, result);
 }
 
 HRESULT MediaSourceActivate::Compare(IMFAttributes* theirs,
@@ -53,34 +53,34 @@ HRESULT MediaSourceActivate::Compare(IMFAttributes* theirs,
     return attributes_->Compare(theirs, match_type, result);
 }
 
-HRESULT MediaSourceActivate::GetUINT32(REFGUID key, UINT32* value) {
-    return attributes_->GetUINT32(key, value);
+HRESULT MediaSourceActivate::GetUINT32(REFGUID key, UINT32* result) {
+    return attributes_->GetUINT32(key, result);
 }
 
-HRESULT MediaSourceActivate::GetUINT64(REFGUID key, UINT64* value) {
-    return attributes_->GetUINT64(key, value);
+HRESULT MediaSourceActivate::GetUINT64(REFGUID key, UINT64* result) {
+    return attributes_->GetUINT64(key, result);
 }
 
-HRESULT MediaSourceActivate::GetDouble(REFGUID key, double* value) {
-    return attributes_->GetDouble(key, value);
+HRESULT MediaSourceActivate::GetDouble(REFGUID key, double* result) {
+    return attributes_->GetDouble(key, result);
 }
 
-HRESULT MediaSourceActivate::GetGUID(REFGUID key, GUID* value) {
-    return attributes_->GetGUID(key, value);
+HRESULT MediaSourceActivate::GetGUID(REFGUID key, GUID* result) {
+    return attributes_->GetGUID(key, result);
 }
 
 HRESULT MediaSourceActivate::GetStringLength(REFGUID key, UINT32* length) {
     return attributes_->GetStringLength(key, length);
 }
 
-HRESULT MediaSourceActivate::GetString(REFGUID key, LPWSTR value,
-                                       UINT32 value_size, UINT32* length) {
-    return attributes_->GetString(key, value, value_size, length);
+HRESULT MediaSourceActivate::GetString(REFGUID key, LPWSTR buffer,
+                                       UINT32 buffer_size, UINT32* length) {
+    return attributes_->GetString(key, buffer, buffer_size, length);
 }
 
-HRESULT MediaSourceActivate::GetAllocatedString(REFGUID key, LPWSTR* value,
+HRESULT MediaSourceActivate::GetAllocatedString(REFGUID key, LPWSTR* result,
                                                 UINT32* length) {
-    return attributes_->GetAllocatedString(key, value, length);
+    return attributes_->GetAllocatedString(key, result, length);
 }
 
 HRESULT MediaSourceActivate::GetBlobSize(REFGUID key, UINT32* size) {
@@ -102,8 +102,8 @@ HRESULT MediaSourceActivate::GetUnknown(REFGUID key, REFIID riid,
     return attributes_->GetUnknown(key, riid, object);
 }
 
-HRESULT MediaSourceActivate::SetItem(REFGUID key, REFPROPVARIANT value) {
-    return attributes_->SetItem(key, value);
+HRESULT MediaSourceActivate::SetItem(REFGUID key, REFPROPVARIANT item) {
+    return attributes_->SetItem(key, item);
 }
 
 HRESULT MediaSourceActivate::DeleteItem(REFGUID key) {
@@ -114,24 +114,24 @@ HRESULT MediaSourceActivate::DeleteAllItems() {
     return attributes_->DeleteAllItems();
 }
 
-HRESULT MediaSourceActivate::SetUINT32(REFGUID key, UINT32 value) {
-    return attributes_->SetUINT32(key, value);
+HRESULT MediaSourceActivate::SetUINT32(REFGUID key, UINT32 item) {
+    return attributes_->SetUINT32(key, item);
 }
 
-HRESULT MediaSourceActivate::SetUINT64(REFGUID key, UINT64 value) {
-    return attributes_->SetUINT64(key, value);
+HRESULT MediaSourceActivate::SetUINT64(REFGUID key, UINT64 item) {
+    return attributes_->SetUINT64(key, item);
 }
 
-HRESULT MediaSourceActivate::SetDouble(REFGUID key, double value) {
-    return attributes_->SetDouble(key, value);
+HRESULT MediaSourceActivate::SetDouble(REFGUID key, double item) {
+    return attributes_->SetDouble(key, item);
 }
 
-HRESULT MediaSourceActivate::SetGUID(REFGUID key, REFGUID value) {
-    return attributes_->SetGUID(key, value);
+HRESULT MediaSourceActivate::SetGUID(REFGUID key, REFGUID item) {
+    return attributes_->SetGUID(key, item);
 }
 
-HRESULT MediaSourceActivate::SetString(REFGUID key, LPCWSTR value) {
-    return attributes_->SetString(key, value);
+HRESULT MediaSourceActivate::SetString(REFGUID key, LPCWSTR item) {
+    return attributes_->SetString(key, item);
 }
 
 HRESULT MediaSourceActivate::SetBlob(REFGUID key, const UINT8* buffer,
@@ -152,8 +152,8 @@ HRESULT MediaSourceActivate::GetCount(UINT32* count) {
 }
 
 HRESULT MediaSourceActivate::GetItemByIndex(UINT32 index, GUID* key,
-                                            PROPVARIANT* value) {
-    return attributes_->GetItemByIndex(index, key, value);
+                                            PROPVARIANT* result) {
+    return attributes_->GetItemByIndex(index, key, result);
 }
 
 HRESULT MediaSourceActivate::CopyAllItems(IMFAttributes* destination) {

--- a/src/VirtualCamera/src/MediaSourceActivate.h
+++ b/src/VirtualCamera/src/MediaSourceActivate.h
@@ -21,21 +21,21 @@ public:
     IFACEMETHODIMP ShutdownObject() override;
     IFACEMETHODIMP DetachObject() override;
 
-    IFACEMETHODIMP GetItem(REFGUID key, PROPVARIANT* value) override;
+    IFACEMETHODIMP GetItem(REFGUID key, PROPVARIANT* result) override;
     IFACEMETHODIMP GetItemType(REFGUID key, MF_ATTRIBUTE_TYPE* type) override;
-    IFACEMETHODIMP CompareItem(REFGUID key, REFPROPVARIANT value,
+    IFACEMETHODIMP CompareItem(REFGUID key, REFPROPVARIANT item,
                               BOOL* result) override;
     IFACEMETHODIMP Compare(IMFAttributes* theirs,
                           MF_ATTRIBUTES_MATCH_TYPE match_type,
                           BOOL* result) override;
-    IFACEMETHODIMP GetUINT32(REFGUID key, UINT32* value) override;
-    IFACEMETHODIMP GetUINT64(REFGUID key, UINT64* value) override;
-    IFACEMETHODIMP GetDouble(REFGUID key, double* value) override;
-    IFACEMETHODIMP GetGUID(REFGUID key, GUID* value) override;
+    IFACEMETHODIMP GetUINT32(REFGUID key, UINT32* result) override;
+    IFACEMETHODIMP GetUINT64(REFGUID key, UINT64* result) override;
+    IFACEMETHODIMP GetDouble(REFGUID key, double* result) override;
+    IFACEMETHODIMP GetGUID(REFGUID key, GUID* result) override;
     IFACEMETHODIMP GetStringLength(REFGUID key, UINT32* length) override;
-    IFACEMETHODIMP GetString(REFGUID key, LPWSTR value, UINT32 value_size,
+    IFACEMETHODIMP GetString(REFGUID key, LPWSTR buffer, UINT32 buffer_size,
                             UINT32* length) override;
-    IFACEMETHODIMP GetAllocatedString(REFGUID key, LPWSTR* value,
+    IFACEMETHODIMP GetAllocatedString(REFGUID key, LPWSTR* result,
                                      UINT32* length) override;
     IFACEMETHODIMP GetBlobSize(REFGUID key, UINT32* size) override;
     IFACEMETHODIMP GetBlob(REFGUID key, UINT8* buffer, UINT32 buffer_size,
@@ -43,14 +43,14 @@ public:
     IFACEMETHODIMP GetAllocatedBlob(REFGUID key, UINT8** buffer,
                                    UINT32* size) override;
     IFACEMETHODIMP GetUnknown(REFGUID key, REFIID riid, void** object) override;
-    IFACEMETHODIMP SetItem(REFGUID key, REFPROPVARIANT value) override;
+    IFACEMETHODIMP SetItem(REFGUID key, REFPROPVARIANT item) override;
     IFACEMETHODIMP DeleteItem(REFGUID key) override;
     IFACEMETHODIMP DeleteAllItems() override;
-    IFACEMETHODIMP SetUINT32(REFGUID key, UINT32 value) override;
-    IFACEMETHODIMP SetUINT64(REFGUID key, UINT64 value) override;
-    IFACEMETHODIMP SetDouble(REFGUID key, double value) override;
-    IFACEMETHODIMP SetGUID(REFGUID key, REFGUID value) override;
-    IFACEMETHODIMP SetString(REFGUID key, LPCWSTR value) override;
+    IFACEMETHODIMP SetUINT32(REFGUID key, UINT32 item) override;
+    IFACEMETHODIMP SetUINT64(REFGUID key, UINT64 item) override;
+    IFACEMETHODIMP SetDouble(REFGUID key, double item) override;
+    IFACEMETHODIMP SetGUID(REFGUID key, REFGUID item) override;
+    IFACEMETHODIMP SetString(REFGUID key, LPCWSTR item) override;
     IFACEMETHODIMP SetBlob(REFGUID key, const UINT8* buffer,
                           UINT32 buffer_size) override;
     IFACEMETHODIMP SetUnknown(REFGUID key, IUnknown* object) override;
@@ -58,7 +58,7 @@ public:
     IFACEMETHODIMP UnlockStore() override;
     IFACEMETHODIMP GetCount(UINT32* count) override;
     IFACEMETHODIMP GetItemByIndex(UINT32 index, GUID* key,
-                                 PROPVARIANT* value) override;
+                                 PROPVARIANT* result) override;
     IFACEMETHODIMP CopyAllItems(IMFAttributes* destination) override;
 
 private:


### PR DESCRIPTION
Rename IMFAttributes forwarding parameters to result, item, and buffer according to their direction and purpose. Rename the MediaStream and MediaSource QueueEvent payload parameter to event_value.

The parameter types, COM method signatures, forwarding calls, and runtime behavior remain unchanged. This removes the inherited-member shadow diagnostics previously emitted for MediaSourceActivate and both QueueEvent implementations.

Validation completed before artifact cleanup: native Release build reported zero warnings; native tests passed 6/6; app logic, WPF runtime, driver installer, VC runtime, Apple package, and localization checks passed. No release package is created by this upload.

## Summary

Describe the problem and the chosen solution.

## Validation

- [x] `./scripts/verify_localization.ps1`
- [x] `./build.ps1 -Configuration Release`
- [x] Core protocol tests pass
- [x] GUI behavior checked when applicable
- [x] Real-device result includes ProductType/iOS but no UDID

## Risk review

- [x] No real UDID, pairing record, user path, private screen content or raw USB capture is included
- [x] No unbounded frame/audio queue or UI-thread USB work was introduced
- [x] Driver, elevation and registry behavior is unchanged, or the change is clearly documented
- [x] Protocol activation and stop behavior is unchanged, or tested on a real device
- [x] Third-party binaries, hashes and license obligations are unchanged, or fully documented

## UI evidence

Attach sanitized screenshots for visual changes. Do not include personal phone content.
