### PR TITLE
Polish scrollbars and guard single instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ All notable changes to iPhoneMirror are documented here. The project follows
   same time by distinguishing an older running process from a newer contender.
 - Dispose filtered process handles and conservatively report inaccessible
   processes during the graceful-close and bounded forced-close workflow.
+- Detect an FFmpeg process that exits while the projection audio pipe is still
+  connecting, reporting the real startup failure instead of a later timeout.
 
 ## [1.5.7] - 2026-08-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to iPhoneMirror are documented here. The project follows
 
 ## [Unreleased]
 
+### Added
+
+- Detect an already-running iPhoneMirror instance and present a localized
+  Fluent Acrylic choice to close the other instance or leave the active
+  mirroring session untouched.
+
+### Changed
+
+- Replace the shared default scrollbars with a slimmer, theme-aware treatment
+  that expands smoothly on hover without covering settings content.
+- Keep the settings scrollbar aligned close to the right edge while preserving
+  visible spacing from the rounded workspace border.
+- Keep the About page update action legible with an explicit white foreground
+  in light mode.
+
+### Fixed
+
+- Avoid showing duplicate conflict dialogs when two launches race at nearly the
+  same time by distinguishing an older running process from a newer contender.
+- Dispose filtered process handles and conservatively report inaccessible
+  processes during the graceful-close and bounded forced-close workflow.
+
 ## [1.5.7] - 2026-08-03
 
 ### Changed

--- a/src/App.Logic.Tests/Program.cs
+++ b/src/App.Logic.Tests/Program.cs
@@ -7,6 +7,15 @@ using IPhoneMirror.App.Updater;
 using IPhoneMirror.Shared.Networking;
 using IPhoneMirror.SharedUI.Services;
 
+const string delayedExitEnvironment =
+    "IPHONE_MIRROR_TEST_DELAYED_PROCESS_EXIT_MS";
+if (int.TryParse(Environment.GetEnvironmentVariable(delayedExitEnvironment),
+        out var delayedExitMilliseconds) && delayedExitMilliseconds > 0)
+{
+    await Task.Delay(delayedExitMilliseconds);
+    return;
+}
+
 var diagnosticTestRoot = Path.Combine(Path.GetTempPath(),
     $"iPhoneMirror-test-logs-{Guid.NewGuid():N}");
 Environment.SetEnvironmentVariable("IPHONE_MIRROR_APP_LOG_DIRECTORY",
@@ -1354,17 +1363,32 @@ await using (var immediateExitOutput = new MediaOutputService((_, _, _) => null,
             1, 48000, 2, 16, new byte[4])
         : null))
 {
-    var immediateExitCapabilities = ffmpegCapabilities with
+    var previousDelayedExit = Environment.GetEnvironmentVariable(
+        delayedExitEnvironment, EnvironmentVariableTarget.Process);
+    try
     {
-        FfmpegPath = Path.Combine(Environment.SystemDirectory, "whoami.exe"),
-    };
-    await ThrowsAsync<InvalidOperationException>(() => immediateExitOutput.StartAsync(
-            1, processTestRequest, immediateExitCapabilities),
-        "an output process that exits during startup is rejected");
+        Environment.SetEnvironmentVariable(delayedExitEnvironment, "750",
+            EnvironmentVariableTarget.Process);
+        var delayedExitCapabilities = ffmpegCapabilities with
+        {
+            FfmpegPath = Environment.ProcessPath ??
+                throw new InvalidOperationException(
+                    "The test process executable path is unavailable."),
+        };
+        await ThrowsAsync<InvalidOperationException>(() =>
+                immediateExitOutput.StartAsync(1, processTestRequest,
+                    delayedExitCapabilities),
+            "an output process that exits during the audio handshake is rejected");
+    }
+    finally
+    {
+        Environment.SetEnvironmentVariable(delayedExitEnvironment,
+            previousDelayedExit, EnvironmentVariableTarget.Process);
+    }
     Equal(false, immediateExitOutput.IsRunning,
-        "immediate process exit does not publish a running output");
+        "startup process exit does not publish a running output");
     Equal(0UL, immediateExitOutput.SessionHandle,
-        "immediate process exit does not retain the session handle");
+        "startup process exit does not retain the session handle");
 }
 
 await using (var failedStartOutput = new MediaOutputService((_, _, _) => null,

--- a/src/App.Logic.Tests/Program.cs
+++ b/src/App.Logic.Tests/Program.cs
@@ -238,6 +238,7 @@ foreach (var requiredThemeKey in new[]
              "CaptureStartBrush", "CaptureStopBrush", "CaptureActionTextBrush",
              "PrimaryActionBrush", "PrimaryActionHoverBrush",
              "PrimaryActionPressedBrush", "PrimaryActionTextBrush",
+             "AboutCheckUpdatesTextBrush",
              "PrimaryActionFocusBrush", "PrimaryActionDisabledBrush",
              "PrimaryActionDisabledTextBrush",
              "ScrollTrackBrush", "ScrollTrackHoverBrush", "ScrollThumbBrush",
@@ -268,13 +269,18 @@ foreach (var reusableControl in new[]
 Equal(true,
     modernControlsText.Contains("<Style TargetType=\"{x:Type ScrollBar}\">",
         StringComparison.Ordinal) &&
-    modernControlsText.Contains("<Setter Property=\"Width\" Value=\"8\"/>",
+    modernControlsText.Contains("<Setter Property=\"Width\" Value=\"6\"/>",
         StringComparison.Ordinal) &&
-    modernControlsText.Contains("<Setter Property=\"Height\" Value=\"8\"/>",
+    modernControlsText.Contains("<Setter Property=\"Height\" Value=\"6\"/>",
         StringComparison.Ordinal) &&
-    modernControlsText.Contains("CornerRadius=\"2.5\"", StringComparison.Ordinal) &&
-    modernControlsText.Contains("MinHeight=\"24\"", StringComparison.Ordinal) &&
-    modernControlsText.Contains("MinWidth=\"24\"", StringComparison.Ordinal) &&
+    modernControlsText.Contains("CornerRadius=\"2\"", StringComparison.Ordinal) &&
+    modernControlsText.Contains("MinHeight\" Value=\"28\"", StringComparison.Ordinal) &&
+    modernControlsText.Contains("MinWidth\" Value=\"28\"", StringComparison.Ordinal) &&
+    modernControlsText.Contains("Storyboard.TargetProperty=\"Width\"",
+        StringComparison.Ordinal) &&
+    modernControlsText.Contains("Storyboard.TargetProperty=\"Height\"",
+        StringComparison.Ordinal) &&
+    modernControlsText.Contains("To=\"4\"", StringComparison.Ordinal) &&
     modernControlsText.Contains("QuadraticEase", StringComparison.Ordinal) &&
     modernControlsText.Contains("PageLeftCommand", StringComparison.Ordinal) &&
     modernControlsText.Contains("PageRightCommand", StringComparison.Ordinal),
@@ -496,9 +502,31 @@ Equal(true, aboutWindowText.StartsWith("<ui:FluentWindow", StringComparison.Ordi
     "about window uses FluentWindow with Mica");
 Equal(true, aboutWindowText.Contains("{DynamicResource CheckForUpdates}",
                 StringComparison.Ordinal) &&
-            aboutWindowText.Contains("Style=\"{StaticResource PrimaryButton}\"",
+            aboutWindowText.Contains(
+                "Style=\"{StaticResource AboutCheckUpdatesButtonStyle}\"",
+                StringComparison.Ordinal) &&
+            aboutWindowText.Contains(
+                "Value=\"{DynamicResource AboutCheckUpdatesTextBrush}\"",
                 StringComparison.Ordinal),
-    "check for updates uses the audited primary action style");
+    "check for updates keeps an explicit theme-aware foreground");
+Equal(true,
+    mainWindowText.Contains("<TranslateTransform X=\"6\"/>",
+        StringComparison.Ordinal),
+    "settings scrollbar keeps the reviewed right-side offset");
+var conflictWindowText = File.ReadAllText(Path.Combine(sourceDirectory,
+    "App", "Windows", "InstanceConflictWindow.xaml"));
+Equal(true,
+    conflictWindowText.StartsWith("<ui:FluentWindow", StringComparison.Ordinal) &&
+    conflictWindowText.Contains("WindowBackdropType=\"Acrylic\"",
+        StringComparison.Ordinal) &&
+    conflictWindowText.Contains("CloseOtherInstancesButton",
+        StringComparison.Ordinal) &&
+    conflictWindowText.Contains("CloseCurrentInstanceButton",
+        StringComparison.Ordinal) &&
+    conflictWindowText.Contains("Style=\"{StaticResource PrimaryButton}\"",
+        StringComparison.Ordinal) &&
+    conflictWindowText.Contains("IsDefault=\"True\"", StringComparison.Ordinal),
+    "instance conflict uses a Fluent Acrylic decision dialog");
 Equal(false, aboutWindowText.Contains("SettingsSection", StringComparison.Ordinal),
     "about content uses lightweight unframed sections instead of a large nested card");
 Equal(true, aboutWindowText.Contains("DiagnosticPath, Mode=OneWay",

--- a/src/App.Runtime.Tests/Program.cs
+++ b/src/App.Runtime.Tests/Program.cs
@@ -85,10 +85,13 @@ internal static class Program
             {
                 ApplyTheme(assembly, AppTheme.Light);
                 AssertThemeBrush(window, "TextBrush", Color.FromRgb(0x1D, 0x1D, 0x1F));
+                AssertThemeBrush(window, "AboutCheckUpdatesTextBrush", Colors.White);
                 AssertBackdropBackground(window);
 
                 ApplyTheme(assembly, AppTheme.Dark);
                 AssertThemeBrush(window, "TextBrush", Color.FromRgb(0xF5, 0xF5, 0xF7));
+                AssertThemeBrush(window, "AboutCheckUpdatesTextBrush",
+                    Color.FromRgb(0x0F, 0x14, 0x19));
                 AssertBackdropBackground(window);
             }
             finally

--- a/src/App/App.xaml.cs
+++ b/src/App/App.xaml.cs
@@ -14,6 +14,8 @@ public partial class App : Application
     private readonly GitHubReleaseClient _releaseClient = new();
     private AboutWindow? _aboutWindow;
     private UpdateWindow? _updateWindow;
+    private SingleInstanceCoordinator? _singleInstanceCoordinator;
+    private int _remoteShutdownRequested;
 
     internal UpdateSettings UpdateSettings { get; private set; } = new();
 
@@ -28,14 +30,34 @@ public partial class App : Application
                 ("arguments", e.Args.Length));
             LocalizationService.Initialize();
             AppIdentity.Initialize();
-            StartupDiagnostics.ValidateRequiredRuntime();
             UpdateSettings = _settingsStore.Load();
             ThemeService.Apply(UpdateSettings.Theme);
-            GitHubReleaseClient.CleanupInterruptedDownloads();
             EventManager.RegisterClassHandler(typeof(Window), FrameworkElement.LoadedEvent,
                 new RoutedEventHandler((sender, _) => ThemeService.Attach((Window)sender)));
             WindowWorkAreaController.EnableForApplication();
             base.OnStartup(e);
+
+            _singleInstanceCoordinator = new SingleInstanceCoordinator();
+            if (!_singleInstanceCoordinator.OwnsPrimaryInstance ||
+                _singleInstanceCoordinator.HasPreExistingInstance())
+            {
+                DiagnosticLogger.Info("lifecycle", "instance_conflict_detected",
+                    ("owns_primary", _singleInstanceCoordinator.OwnsPrimaryInstance));
+                ShutdownMode = ShutdownMode.OnExplicitShutdown;
+                var conflictWindow = new InstanceConflictWindow(_singleInstanceCoordinator);
+                conflictWindow.ShowDialog();
+                if (!conflictWindow.ContinueWithCurrentInstance ||
+                    !_singleInstanceCoordinator.OwnsPrimaryInstance)
+                {
+                    Shutdown(0);
+                    return;
+                }
+            }
+
+            _singleInstanceCoordinator.StartShutdownListener(OnRemoteShutdownRequested);
+            ShutdownMode = ShutdownMode.OnLastWindowClose;
+            StartupDiagnostics.ValidateRequiredRuntime();
+            GitHubReleaseClient.CleanupInterruptedDownloads();
             MainWindow = new MainWindow();
             MainWindow.ContentRendered += OnMainWindowContentRendered;
             MainWindow.Show();
@@ -53,6 +75,17 @@ public partial class App : Application
             }
             Shutdown(-1);
         }
+    }
+
+    private void OnRemoteShutdownRequested()
+    {
+        Dispatcher.BeginInvoke(() =>
+        {
+            if (Interlocked.Exchange(ref _remoteShutdownRequested, 1) != 0) return;
+            DiagnosticLogger.Info("lifecycle", "remote_shutdown_requested");
+            if (MainWindow is { } window) window.Close();
+            else Shutdown(0);
+        });
     }
 
     private async void OnMainWindowContentRendered(object? sender, EventArgs e)
@@ -145,6 +178,8 @@ public partial class App : Application
         {
             DiagnosticLogger.Exception("updater", "client_dispose_failed", error);
         }
+        _singleInstanceCoordinator?.Dispose();
+        _singleInstanceCoordinator = null;
         DiagnosticLogger.Shutdown(e.ApplicationExitCode);
         base.OnExit(e);
     }

--- a/src/App/Localization/Strings.en-US.xaml
+++ b/src/App/Localization/Strings.en-US.xaml
@@ -463,6 +463,13 @@
     <system:String x:Key="NavCollapseDescription">Collapse navigation</system:String>
     <system:String x:Key="NavExpandToolTip">Expand left navigation</system:String>
     <system:String x:Key="AppPreferencesTitle">App settings</system:String>
+    <system:String x:Key="InstanceConflictTitle">iPhoneMirror is already running</system:String>
+    <system:String x:Key="InstanceConflictBody">Another iPhoneMirror instance is currently running. Choose which window to keep.</system:String>
+    <system:String x:Key="InstanceConflictHint">Closing the other window continues this launch. Closing this window leaves the active mirroring session untouched.</system:String>
+    <system:String x:Key="CloseOtherInstances">Close other window</system:String>
+    <system:String x:Key="CloseCurrentInstance">Close this window</system:String>
+    <system:String x:Key="ClosingOtherInstances">Safely closing the other iPhoneMirror window…</system:String>
+    <system:String x:Key="CloseOtherInstancesFailedFormat">{0} iPhoneMirror instance could not be closed. Close it from the taskbar or Task Manager, then try again.</system:String>
     <system:String x:Key="Minimize">Minimize</system:String>
     <system:String x:Key="Maximize">Maximize</system:String>
 </ResourceDictionary>

--- a/src/App/Localization/Strings.zh-CN.xaml
+++ b/src/App/Localization/Strings.zh-CN.xaml
@@ -463,6 +463,13 @@
     <system:String x:Key="NavCollapseDescription">收起导航</system:String>
     <system:String x:Key="NavExpandToolTip">展开左侧导航</system:String>
     <system:String x:Key="AppPreferencesTitle">应用设置</system:String>
+    <system:String x:Key="InstanceConflictTitle">iPhoneMirror 已在运行</system:String>
+    <system:String x:Key="InstanceConflictBody">检测到另一个 iPhoneMirror 程序正在运行。请选择要保留的窗口。</system:String>
+    <system:String x:Key="InstanceConflictHint">关闭其他窗口后，当前窗口会继续启动；关闭当前窗口不会影响已经运行的投屏。</system:String>
+    <system:String x:Key="CloseOtherInstances">关闭其他窗口</system:String>
+    <system:String x:Key="CloseCurrentInstance">关闭当前窗口</system:String>
+    <system:String x:Key="ClosingOtherInstances">正在安全关闭其他 iPhoneMirror 窗口…</system:String>
+    <system:String x:Key="CloseOtherInstancesFailedFormat">仍有 {0} 个 iPhoneMirror 实例未能关闭。请在任务栏或任务管理器中关闭后重试。</system:String>
     <system:String x:Key="Minimize">最小化</system:String>
     <system:String x:Key="Maximize">最大化</system:String>
 </ResourceDictionary>

--- a/src/App/MainWindow.xaml
+++ b/src/App/MainWindow.xaml
@@ -1048,11 +1048,21 @@
 
             <Border x:Name="ControlPanel" Grid.Column="4" Width="0"
                     Style="{StaticResource WorkspaceCardBorder}"
-                    Padding="16,16,7,16" Visibility="Collapsed">
+                    Padding="16,16,1,16" Visibility="Collapsed">
                 <ScrollViewer HorizontalScrollBarVisibility="Disabled"
                               VerticalScrollBarVisibility="Auto"
                               PanningMode="VerticalOnly">
-                    <StackPanel Margin="0,0,7,0">
+                    <ScrollViewer.Resources>
+                        <Style TargetType="ScrollBar"
+                               BasedOn="{StaticResource {x:Type ScrollBar}}">
+                            <Setter Property="RenderTransform">
+                                <Setter.Value>
+                                    <TranslateTransform X="6"/>
+                                </Setter.Value>
+                            </Setter>
+                        </Style>
+                    </ScrollViewer.Resources>
+                    <StackPanel Margin="0,0,10,0">
                         <Grid>
                             <TextBlock Text="{DynamicResource ControlTitle}" FontSize="16" FontWeight="SemiBold"
                                        VerticalAlignment="Center"/>

--- a/src/App/Services/MediaOutputService.cs
+++ b/src/App/Services/MediaOutputService.cs
@@ -150,6 +150,14 @@ internal sealed class MediaOutputService : IAsyncDisposable
                 await ObserveStartupAsync(process, cancellationToken);
                 if (pipeConnection is not null)
                 {
+                    var processExit = process.WaitForExitAsync(cancellationToken);
+                    var completed = await Task.WhenAny(pipeConnection, processExit);
+                    if (completed == processExit)
+                    {
+                        await processExit;
+                        await ThrowStartupExitAsync(process, cancellationToken);
+                    }
+
                     try { await pipeConnection; }
                     catch (OperationCanceledException)
                         when (!cancellationToken.IsCancellationRequested)
@@ -657,6 +665,13 @@ internal sealed class MediaOutputService : IAsyncDisposable
             if (!process.HasExited) return;
         }
 
+        cancellationToken.ThrowIfCancellationRequested();
+        await ThrowStartupExitAsync(process, cancellationToken);
+    }
+
+    private async Task ThrowStartupExitAsync(Process process,
+        CancellationToken cancellationToken)
+    {
         cancellationToken.ThrowIfCancellationRequested();
         process.WaitForExit();
         await Task.Yield();

--- a/src/App/Services/SingleInstanceCoordinator.cs
+++ b/src/App/Services/SingleInstanceCoordinator.cs
@@ -1,0 +1,245 @@
+using System.Diagnostics;
+
+namespace IPhoneMirror.App.Services;
+
+internal sealed class SingleInstanceCoordinator : IDisposable
+{
+    private const string MutexName = @"Local\IPhoneMirror.App.SingleInstance";
+    private const string ShutdownEventName = @"Local\IPhoneMirror.App.SingleInstance.Shutdown";
+
+    private readonly Mutex _mutex;
+    private readonly EventWaitHandle _shutdownEvent;
+    private readonly int _currentProcessId;
+    private readonly int _currentSessionId;
+    private readonly string _currentProcessName;
+    private readonly DateTime _currentStartedAtUtc;
+    private RegisteredWaitHandle? _shutdownRegistration;
+    private bool _ownsPrimaryInstance;
+    private bool _disposed;
+
+    internal SingleInstanceCoordinator()
+    {
+        using var current = Process.GetCurrentProcess();
+        _currentProcessId = current.Id;
+        _currentSessionId = current.SessionId;
+        _currentProcessName = current.ProcessName;
+        _currentStartedAtUtc = TryGetStartTimeUtc(current) ?? DateTime.UtcNow;
+        _mutex = new Mutex(false, MutexName);
+        _shutdownEvent = new EventWaitHandle(
+            false, EventResetMode.AutoReset, ShutdownEventName);
+        _ownsPrimaryInstance = TryAcquireMutex(TimeSpan.Zero);
+    }
+
+    internal bool OwnsPrimaryInstance => _ownsPrimaryInstance;
+
+    internal bool HasPreExistingInstance()
+    {
+        var processes = FindOtherInstances();
+        try
+        {
+            return processes.Any(process =>
+            {
+                var startedAtUtc = TryGetStartTimeUtc(process);
+                return startedAtUtc is null || startedAtUtc < _currentStartedAtUtc;
+            });
+        }
+        finally
+        {
+            foreach (var process in processes) process.Dispose();
+        }
+    }
+
+    internal void StartShutdownListener(Action shutdownRequested)
+    {
+        ArgumentNullException.ThrowIfNull(shutdownRequested);
+        if (!_ownsPrimaryInstance || _shutdownRegistration is not null) return;
+
+        _shutdownRegistration = ThreadPool.RegisterWaitForSingleObject(
+            _shutdownEvent,
+            (_, timedOut) =>
+            {
+                if (!timedOut) shutdownRequested();
+            },
+            null,
+            Timeout.InfiniteTimeSpan,
+            executeOnlyOnce: false);
+    }
+
+    internal Task<SingleInstanceCloseResult> CloseOtherInstancesAsync(
+        TimeSpan timeout) => Task.Run(() => CloseOtherInstances(timeout));
+
+    internal bool TryAcquirePrimaryInstance(TimeSpan timeout) =>
+        TryAcquireMutex(timeout);
+
+    private SingleInstanceCloseResult CloseOtherInstances(TimeSpan timeout)
+    {
+        ThrowIfDisposed();
+        if (timeout <= TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(timeout));
+
+        var elapsed = Stopwatch.StartNew();
+        var gracefulTimeout = TimeSpan.FromMilliseconds(Math.Min(
+            12_000, timeout.TotalMilliseconds * 0.65));
+        var processes = FindOtherInstances();
+        var closeRequested = new HashSet<int>();
+
+        try
+        {
+            // A secondary updated instance can request shutdown even while the
+            // primary window is loading. A primary closing a legacy instance
+            // must not signal its own listener.
+            if (!_ownsPrimaryInstance) _shutdownEvent.Set();
+
+            while (elapsed.Elapsed < gracefulTimeout)
+            {
+                var remaining = 0;
+                foreach (var process in processes)
+                {
+                    var counted = false;
+                    try
+                    {
+                        process.Refresh();
+                        if (process.HasExited) continue;
+                        ++remaining;
+                        counted = true;
+                        if (process.MainWindowHandle != 0 &&
+                            !closeRequested.Contains(process.Id) &&
+                            process.CloseMainWindow())
+                            closeRequested.Add(process.Id);
+                    }
+                    catch (InvalidOperationException)
+                    {
+                        // The process exited between Refresh and inspection.
+                    }
+                    catch (System.ComponentModel.Win32Exception)
+                    {
+                        if (!counted) ++remaining;
+                    }
+                }
+
+                if (remaining == 0)
+                    return new SingleInstanceCloseResult(true, 0);
+
+                Thread.Sleep(120);
+            }
+
+            // Legacy builds do not listen for the named shutdown event and may
+            // have no discoverable main window. The explicit user action grants
+            // a bounded forced-close fallback after the graceful period.
+            foreach (var process in processes)
+            {
+                try
+                {
+                    process.Refresh();
+                    if (!process.HasExited) process.Kill(entireProcessTree: true);
+                }
+                catch (InvalidOperationException) { }
+                catch (System.ComponentModel.Win32Exception) { }
+                catch (NotSupportedException) { }
+            }
+
+            while (elapsed.Elapsed < timeout)
+            {
+                if (CountRemainingInstances(processes) == 0)
+                    return new SingleInstanceCloseResult(true, 0);
+                Thread.Sleep(100);
+            }
+
+            var remainingCount = CountRemainingInstances(processes);
+            return new SingleInstanceCloseResult(
+                false, Math.Max(remainingCount, 1));
+        }
+        finally
+        {
+            foreach (var process in processes) process.Dispose();
+        }
+    }
+
+    private static int CountRemainingInstances(IEnumerable<Process> processes) =>
+        processes.Count(process =>
+        {
+            try
+            {
+                process.Refresh();
+                return !process.HasExited;
+            }
+            catch (InvalidOperationException)
+            {
+                return false;
+            }
+            catch (System.ComponentModel.Win32Exception)
+            {
+                return true;
+            }
+            catch (NotSupportedException)
+            {
+                return true;
+            }
+        });
+
+    private List<Process> FindOtherInstances()
+    {
+        var matches = new List<Process>();
+        foreach (var process in Process.GetProcessesByName(_currentProcessName))
+        {
+            if (process.Id != _currentProcessId &&
+                TryGetSessionId(process) == _currentSessionId)
+            {
+                matches.Add(process);
+            }
+            else
+            {
+                process.Dispose();
+            }
+        }
+        return matches;
+    }
+
+    private static int TryGetSessionId(Process process)
+    {
+        try { return process.SessionId; }
+        catch { return -1; }
+    }
+
+    private static DateTime? TryGetStartTimeUtc(Process process)
+    {
+        try { return process.StartTime.ToUniversalTime(); }
+        catch { return null; }
+    }
+
+    private bool TryAcquireMutex(TimeSpan timeout)
+    {
+        if (_ownsPrimaryInstance) return true;
+        try
+        {
+            _ownsPrimaryInstance = _mutex.WaitOne(timeout);
+        }
+        catch (AbandonedMutexException)
+        {
+            _ownsPrimaryInstance = true;
+        }
+        return _ownsPrimaryInstance;
+    }
+
+    private void ThrowIfDisposed() =>
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        _shutdownRegistration?.Unregister(null);
+        _shutdownRegistration = null;
+        _shutdownEvent.Dispose();
+        if (_ownsPrimaryInstance)
+        {
+            try { _mutex.ReleaseMutex(); }
+            catch (ApplicationException) { }
+            _ownsPrimaryInstance = false;
+        }
+        _mutex.Dispose();
+    }
+}
+
+internal readonly record struct SingleInstanceCloseResult(
+    bool Succeeded, int RemainingInstanceCount);

--- a/src/App/Windows/AboutWindow.xaml
+++ b/src/App/Windows/AboutWindow.xaml
@@ -11,6 +11,14 @@
         Background="{DynamicResource AppBackgroundBrush}"
         Foreground="{DynamicResource TextBrush}"
         AutomationProperties.AutomationId="AboutWindow">
+    <ui:FluentWindow.Resources>
+        <Style x:Key="AboutCheckUpdatesButtonStyle"
+               TargetType="Button"
+               BasedOn="{StaticResource PrimaryButton}">
+            <Setter Property="Foreground"
+                    Value="{DynamicResource AboutCheckUpdatesTextBrush}"/>
+        </Style>
+    </ui:FluentWindow.Resources>
     <Grid Style="{StaticResource SubWindowPageRoot}"
           animations:PageTransition.IsEnabled="True">
         <Grid.RowDefinitions>
@@ -75,7 +83,7 @@
                             <WrapPanel>
                                 <Button Content="{DynamicResource CheckForUpdates}"
                                         Click="OnCheckUpdatesClick"
-                                        Style="{StaticResource PrimaryButton}"
+                                        Style="{StaticResource AboutCheckUpdatesButtonStyle}"
                                         MinWidth="138" Margin="0,0,8,8"/>
                                 <Button Content="GitHub" Click="OnGitHubClick"
                                         MinWidth="96" Margin="0,0,8,8"/>

--- a/src/App/Windows/InstanceConflictWindow.xaml
+++ b/src/App/Windows/InstanceConflictWindow.xaml
@@ -1,0 +1,110 @@
+<ui:FluentWindow x:Class="IPhoneMirror.App.Windows.InstanceConflictWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:animations="clr-namespace:IPhoneMirror.UI.Animations"
+        xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
+        Title="{DynamicResource InstanceConflictTitle}"
+        Width="560" SizeToContent="Height" MinHeight="320" MaxHeight="480"
+        ResizeMode="NoResize" WindowStartupLocation="CenterScreen"
+        WindowStyle="None" ExtendsContentIntoTitleBar="True"
+        WindowBackdropType="Acrylic" WindowCornerPreference="Round"
+        Background="{DynamicResource AppBackgroundBrush}"
+        Foreground="{DynamicResource TextBrush}"
+        ShowInTaskbar="True"
+        AutomationProperties.AutomationId="InstanceConflictWindow"
+        Closing="OnWindowClosing">
+    <Border Style="{StaticResource ModernDialogSurface}" Margin="10">
+        <Grid animations:PageTransition.IsEnabled="True">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="16"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="14"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="20"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+
+            <Grid Style="{StaticResource SubWindowHeader}"
+                  MouseLeftButtonDown="OnHeaderMouseLeftButtonDown">
+                <TextBlock Text="{DynamicResource InstanceConflictTitle}"
+                           Style="{StaticResource SubWindowTitle}"
+                           Margin="0,0,48,0"/>
+                <Button x:Name="HeaderCloseButton"
+                        Style="{StaticResource SubWindowCloseButton}"
+                        Click="OnCloseCurrentClick">
+                    <TextBlock FontFamily="Segoe Fluent Icons"
+                               Text="&#xE8BB;" FontSize="14"/>
+                </Button>
+            </Grid>
+
+            <Border Grid.Row="2"
+                    Background="{DynamicResource WarningSurfaceBrush}"
+                    BorderBrush="{DynamicResource WarningBrush}"
+                    BorderThickness="1" CornerRadius="14" Padding="18,16">
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="46"/>
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
+                    <Border Width="34" Height="34" CornerRadius="17"
+                            Background="{DynamicResource WarningBrush}"
+                            VerticalAlignment="Top">
+                        <TextBlock FontFamily="Segoe Fluent Icons"
+                                   Text="&#xE7BA;" FontSize="16"
+                                   Foreground="{DynamicResource OnAccentBrush}"
+                                   HorizontalAlignment="Center"
+                                   VerticalAlignment="Center"/>
+                    </Border>
+                    <StackPanel Grid.Column="1">
+                        <TextBlock Text="{DynamicResource InstanceConflictBody}"
+                                   FontSize="13" LineHeight="21"
+                                   TextWrapping="Wrap"/>
+                        <TextBlock Text="{DynamicResource InstanceConflictHint}"
+                                   Foreground="{DynamicResource MutedTextBrush}"
+                                   FontSize="11" LineHeight="18"
+                                   TextWrapping="Wrap" Margin="0,8,0,0"/>
+                    </StackPanel>
+                </Grid>
+            </Border>
+
+            <Grid Grid.Row="4" MinHeight="20">
+                <StackPanel x:Name="BusyPanel" Orientation="Horizontal"
+                            Visibility="Collapsed">
+                    <TextBlock Width="18" Height="18"
+                               FontFamily="Segoe Fluent Icons"
+                               Text="&#xE895;" FontSize="14"
+                               Foreground="{DynamicResource PrimaryActionBrush}"
+                               VerticalAlignment="Center"
+                               RenderTransformOrigin="0.5,0.5">
+                        <TextBlock.RenderTransform>
+                            <RotateTransform x:Name="BusyRotation"/>
+                        </TextBlock.RenderTransform>
+                    </TextBlock>
+                    <TextBlock Text="{DynamicResource ClosingOtherInstances}"
+                               Foreground="{DynamicResource MutedTextBrush}"
+                               FontSize="12" VerticalAlignment="Center"
+                               Margin="7,0,0,0"/>
+                </StackPanel>
+                <TextBlock x:Name="ErrorText" Visibility="Collapsed"
+                           Foreground="{DynamicResource ErrorBrush}"
+                           FontSize="12" LineHeight="18" TextWrapping="Wrap"/>
+            </Grid>
+
+            <StackPanel Grid.Row="6" Orientation="Horizontal"
+                        HorizontalAlignment="Right">
+                <Button x:Name="CloseOtherInstancesButton"
+                        Content="{DynamicResource CloseOtherInstances}"
+                        MinWidth="150" Margin="0,0,8,0"
+                        AutomationProperties.AutomationId="CloseOtherInstancesButton"
+                        Click="OnCloseOtherInstancesClick"/>
+                <Button x:Name="CloseCurrentInstanceButton"
+                        Content="{DynamicResource CloseCurrentInstance}"
+                        MinWidth="150" Style="{StaticResource PrimaryButton}"
+                        IsDefault="True"
+                        AutomationProperties.AutomationId="CloseCurrentInstanceButton"
+                        Click="OnCloseCurrentClick"/>
+            </StackPanel>
+        </Grid>
+    </Border>
+</ui:FluentWindow>

--- a/src/App/Windows/InstanceConflictWindow.xaml.cs
+++ b/src/App/Windows/InstanceConflictWindow.xaml.cs
@@ -1,0 +1,111 @@
+using System.ComponentModel;
+using System.Windows;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Animation;
+using IPhoneMirror.App.Localization;
+using IPhoneMirror.App.Services;
+
+namespace IPhoneMirror.App.Windows;
+
+public partial class InstanceConflictWindow : Wpf.Ui.Controls.FluentWindow
+{
+    private readonly SingleInstanceCoordinator _coordinator;
+    private bool _allowClose;
+    private bool _isClosingOtherInstances;
+
+    internal InstanceConflictWindow(SingleInstanceCoordinator coordinator)
+    {
+        _coordinator = coordinator;
+        InitializeComponent();
+    }
+
+    internal bool ContinueWithCurrentInstance { get; private set; }
+
+    private async void OnCloseOtherInstancesClick(object sender, RoutedEventArgs e)
+    {
+        if (_isClosingOtherInstances) return;
+        SetBusy(true);
+        try
+        {
+            var result = await _coordinator.CloseOtherInstancesAsync(
+                TimeSpan.FromSeconds(20));
+            if (result.Succeeded &&
+                _coordinator.TryAcquirePrimaryInstance(TimeSpan.FromSeconds(2)))
+            {
+                DiagnosticLogger.Info("lifecycle", "instance_conflict_resolved",
+                    ("action", "close_other"));
+                ContinueWithCurrentInstance = true;
+                _allowClose = true;
+                DialogResult = true;
+                return;
+            }
+
+            ShowCloseFailure(result.RemainingInstanceCount);
+        }
+        catch (Exception error)
+        {
+            DiagnosticLogger.Exception("lifecycle",
+                "instance_conflict_close_failed", error);
+            ShowCloseFailure(1);
+        }
+    }
+
+    private void OnCloseCurrentClick(object sender, RoutedEventArgs e)
+    {
+        DiagnosticLogger.Info("lifecycle", "instance_conflict_resolved",
+            ("action", "close_current"));
+        ContinueWithCurrentInstance = false;
+        _allowClose = true;
+        DialogResult = false;
+    }
+
+    private void SetBusy(bool busy)
+    {
+        _isClosingOtherInstances = busy;
+        CloseOtherInstancesButton.IsEnabled = !busy;
+        CloseCurrentInstanceButton.IsEnabled = !busy;
+        HeaderCloseButton.IsEnabled = !busy;
+        ErrorText.Visibility = Visibility.Collapsed;
+        BusyPanel.Visibility = busy ? Visibility.Visible : Visibility.Collapsed;
+        if (busy)
+        {
+            BusyRotation.BeginAnimation(RotateTransform.AngleProperty,
+                new DoubleAnimation(0, 360, TimeSpan.FromMilliseconds(850))
+                {
+                    RepeatBehavior = RepeatBehavior.Forever,
+                });
+        }
+        else
+        {
+            BusyRotation.BeginAnimation(RotateTransform.AngleProperty, null);
+        }
+    }
+
+    private void ShowCloseFailure(int remainingInstanceCount)
+    {
+        ErrorText.Text = LocalizationService.Format(
+            "CloseOtherInstancesFailedFormat", Math.Max(remainingInstanceCount, 1));
+        DiagnosticLogger.Info("lifecycle", "instance_conflict_close_failed",
+            ("remaining", remainingInstanceCount));
+        ErrorText.Visibility = Visibility.Visible;
+        SetBusy(false);
+    }
+
+    private void OnWindowClosing(object? sender, CancelEventArgs e)
+    {
+        if (_isClosingOtherInstances && !_allowClose)
+        {
+            e.Cancel = true;
+            return;
+        }
+        if (_allowClose) return;
+        ContinueWithCurrentInstance = false;
+        _allowClose = true;
+    }
+
+    private void OnHeaderMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+    {
+        if (e.ChangedButton == MouseButton.Left) DragMove();
+    }
+}

--- a/src/SharedUI/Controls/ModernControls.xaml
+++ b/src/SharedUI/Controls/ModernControls.xaml
@@ -41,53 +41,19 @@
 
     <Style x:Key="ModernVerticalScrollThumbStyle" TargetType="{x:Type Thumb}">
         <Setter Property="Background" Value="{DynamicResource ScrollThumbBrush}"/>
+        <Setter Property="Width" Value="2"/>
+        <Setter Property="MinHeight" Value="28"/>
+        <Setter Property="HorizontalAlignment" Value="Center"/>
+        <Setter Property="Opacity" Value="0.56"/>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type Thumb}">
-                    <Grid Background="Transparent">
-                        <Border x:Name="ThumbRoot"
-                                Width="3"
-                                MinHeight="24"
-                                HorizontalAlignment="Center"
-                                Background="{TemplateBinding Background}"
-                                CornerRadius="2.5"
-                                Opacity="0.78"/>
-                    </Grid>
+                    <Border Background="{TemplateBinding Background}"
+                            CornerRadius="2"
+                            SnapsToDevicePixels="True"/>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsMouseOver" Value="True">
                             <Setter Property="Background" Value="{DynamicResource ScrollThumbHoverBrush}"/>
-                            <Trigger.EnterActions>
-                                <BeginStoryboard>
-                                    <Storyboard>
-                                        <DoubleAnimation Storyboard.TargetName="ThumbRoot"
-                                                         Storyboard.TargetProperty="Width"
-                                                         To="5" Duration="0:0:0.12">
-                                            <DoubleAnimation.EasingFunction>
-                                                <QuadraticEase EasingMode="EaseOut"/>
-                                            </DoubleAnimation.EasingFunction>
-                                        </DoubleAnimation>
-                                        <DoubleAnimation Storyboard.TargetName="ThumbRoot"
-                                                         Storyboard.TargetProperty="Opacity"
-                                                         To="1" Duration="0:0:0.1"/>
-                                    </Storyboard>
-                                </BeginStoryboard>
-                            </Trigger.EnterActions>
-                            <Trigger.ExitActions>
-                                <BeginStoryboard>
-                                    <Storyboard>
-                                        <DoubleAnimation Storyboard.TargetName="ThumbRoot"
-                                                         Storyboard.TargetProperty="Width"
-                                                         To="3" Duration="0:0:0.16">
-                                            <DoubleAnimation.EasingFunction>
-                                                <QuadraticEase EasingMode="EaseOut"/>
-                                            </DoubleAnimation.EasingFunction>
-                                        </DoubleAnimation>
-                                        <DoubleAnimation Storyboard.TargetName="ThumbRoot"
-                                                         Storyboard.TargetProperty="Opacity"
-                                                         To="0.78" Duration="0:0:0.14"/>
-                                    </Storyboard>
-                                </BeginStoryboard>
-                            </Trigger.ExitActions>
                         </Trigger>
                         <Trigger Property="IsDragging" Value="True">
                             <Setter Property="Background" Value="{DynamicResource ScrollThumbPressedBrush}"/>
@@ -100,53 +66,19 @@
 
     <Style x:Key="ModernHorizontalScrollThumbStyle" TargetType="{x:Type Thumb}">
         <Setter Property="Background" Value="{DynamicResource ScrollThumbBrush}"/>
+        <Setter Property="Height" Value="2"/>
+        <Setter Property="MinWidth" Value="28"/>
+        <Setter Property="VerticalAlignment" Value="Center"/>
+        <Setter Property="Opacity" Value="0.56"/>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type Thumb}">
-                    <Grid Background="Transparent">
-                        <Border x:Name="ThumbRoot"
-                                Height="3"
-                                MinWidth="24"
-                                VerticalAlignment="Center"
-                                Background="{TemplateBinding Background}"
-                                CornerRadius="2.5"
-                                Opacity="0.78"/>
-                    </Grid>
+                    <Border Background="{TemplateBinding Background}"
+                            CornerRadius="2"
+                            SnapsToDevicePixels="True"/>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsMouseOver" Value="True">
                             <Setter Property="Background" Value="{DynamicResource ScrollThumbHoverBrush}"/>
-                            <Trigger.EnterActions>
-                                <BeginStoryboard>
-                                    <Storyboard>
-                                        <DoubleAnimation Storyboard.TargetName="ThumbRoot"
-                                                         Storyboard.TargetProperty="Height"
-                                                         To="5" Duration="0:0:0.12">
-                                            <DoubleAnimation.EasingFunction>
-                                                <QuadraticEase EasingMode="EaseOut"/>
-                                            </DoubleAnimation.EasingFunction>
-                                        </DoubleAnimation>
-                                        <DoubleAnimation Storyboard.TargetName="ThumbRoot"
-                                                         Storyboard.TargetProperty="Opacity"
-                                                         To="1" Duration="0:0:0.1"/>
-                                    </Storyboard>
-                                </BeginStoryboard>
-                            </Trigger.EnterActions>
-                            <Trigger.ExitActions>
-                                <BeginStoryboard>
-                                    <Storyboard>
-                                        <DoubleAnimation Storyboard.TargetName="ThumbRoot"
-                                                         Storyboard.TargetProperty="Height"
-                                                         To="3" Duration="0:0:0.16">
-                                            <DoubleAnimation.EasingFunction>
-                                                <QuadraticEase EasingMode="EaseOut"/>
-                                            </DoubleAnimation.EasingFunction>
-                                        </DoubleAnimation>
-                                        <DoubleAnimation Storyboard.TargetName="ThumbRoot"
-                                                         Storyboard.TargetProperty="Opacity"
-                                                         To="0.78" Duration="0:0:0.14"/>
-                                    </Storyboard>
-                                </BeginStoryboard>
-                            </Trigger.ExitActions>
                         </Trigger>
                         <Trigger Property="IsDragging" Value="True">
                             <Setter Property="Background" Value="{DynamicResource ScrollThumbPressedBrush}"/>
@@ -159,18 +91,22 @@
 
     <Style TargetType="{x:Type ScrollBar}">
         <Setter Property="Background" Value="{DynamicResource ScrollTrackBrush}"/>
-        <Setter Property="Width" Value="8"/>
+        <Setter Property="Width" Value="6"/>
         <Setter Property="Height" Value="Auto"/>
-        <Setter Property="Margin" Value="2,0,0,0"/>
+        <Setter Property="Margin" Value="0"/>
         <Setter Property="Focusable" Value="False"/>
         <Setter Property="SnapsToDevicePixels" Value="True"/>
         <Setter Property="UseLayoutRounding" Value="True"/>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ScrollBar}">
-                    <Border Background="{TemplateBinding Background}"
-                            CornerRadius="4"
-                            SnapsToDevicePixels="True">
+                    <Grid Background="{TemplateBinding Background}" SnapsToDevicePixels="True">
+                        <Border x:Name="TrackSurface"
+                                Width="4"
+                                HorizontalAlignment="Center"
+                                Background="{DynamicResource ScrollTrackHoverBrush}"
+                                CornerRadius="2"
+                                Opacity="0"/>
                         <Track x:Name="PART_Track"
                                Focusable="False"
                                Orientation="{TemplateBinding Orientation}"
@@ -187,7 +123,6 @@
                             </Track.DecreaseRepeatButton>
                             <Track.Thumb>
                                 <Thumb x:Name="ScrollThumb"
-                                       MinHeight="24"
                                        Style="{StaticResource ModernVerticalScrollThumbStyle}"/>
                             </Track.Thumb>
                             <Track.IncreaseRepeatButton>
@@ -197,22 +132,113 @@
                                               Style="{StaticResource InvisibleScrollRepeatButtonStyle}"/>
                             </Track.IncreaseRepeatButton>
                         </Track>
-                    </Border>
+                    </Grid>
                     <ControlTemplate.Triggers>
                         <Trigger Property="Orientation" Value="Horizontal">
                             <Setter TargetName="PART_Track" Property="IsDirectionReversed" Value="False"/>
+                            <Setter TargetName="TrackSurface" Property="Width" Value="Auto"/>
+                            <Setter TargetName="TrackSurface" Property="Height" Value="4"/>
+                            <Setter TargetName="TrackSurface" Property="HorizontalAlignment" Value="Stretch"/>
+                            <Setter TargetName="TrackSurface" Property="VerticalAlignment" Value="Center"/>
                             <Setter TargetName="DecreaseButton" Property="Command" Value="{x:Static ScrollBar.PageLeftCommand}"/>
                             <Setter TargetName="IncreaseButton" Property="Command" Value="{x:Static ScrollBar.PageRightCommand}"/>
-                            <Setter TargetName="ScrollThumb" Property="MinHeight" Value="0"/>
-                            <Setter TargetName="ScrollThumb" Property="MinWidth" Value="24"/>
                             <Setter TargetName="ScrollThumb" Property="Style"
                                     Value="{StaticResource ModernHorizontalScrollThumbStyle}"/>
                         </Trigger>
                         <Trigger Property="IsMouseOver" Value="True">
-                            <Setter Property="Background" Value="{DynamicResource ScrollTrackHoverBrush}"/>
+                            <Setter TargetName="ScrollThumb" Property="Background"
+                                    Value="{DynamicResource ScrollThumbHoverBrush}"/>
+                            <Trigger.EnterActions>
+                                <BeginStoryboard>
+                                    <Storyboard>
+                                        <DoubleAnimation Storyboard.TargetName="TrackSurface"
+                                                         Storyboard.TargetProperty="Opacity"
+                                                         To="0.62" Duration="0:0:0.12"/>
+                                        <DoubleAnimation Storyboard.TargetName="ScrollThumb"
+                                                         Storyboard.TargetProperty="Opacity"
+                                                         To="0.96" Duration="0:0:0.1"/>
+                                    </Storyboard>
+                                </BeginStoryboard>
+                            </Trigger.EnterActions>
+                            <Trigger.ExitActions>
+                                <BeginStoryboard>
+                                    <Storyboard>
+                                        <DoubleAnimation Storyboard.TargetName="TrackSurface"
+                                                         Storyboard.TargetProperty="Opacity"
+                                                         To="0" Duration="0:0:0.2"/>
+                                        <DoubleAnimation Storyboard.TargetName="ScrollThumb"
+                                                         Storyboard.TargetProperty="Opacity"
+                                                         To="0.56" Duration="0:0:0.18"/>
+                                    </Storyboard>
+                                </BeginStoryboard>
+                            </Trigger.ExitActions>
                         </Trigger>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="Orientation" Value="Vertical"/>
+                                <Condition Property="IsMouseOver" Value="True"/>
+                            </MultiTrigger.Conditions>
+                            <MultiTrigger.EnterActions>
+                                <BeginStoryboard>
+                                    <Storyboard>
+                                        <DoubleAnimation Storyboard.TargetName="ScrollThumb"
+                                                         Storyboard.TargetProperty="Width"
+                                                         To="4" Duration="0:0:0.12">
+                                            <DoubleAnimation.EasingFunction>
+                                                <QuadraticEase EasingMode="EaseOut"/>
+                                            </DoubleAnimation.EasingFunction>
+                                        </DoubleAnimation>
+                                    </Storyboard>
+                                </BeginStoryboard>
+                            </MultiTrigger.EnterActions>
+                            <MultiTrigger.ExitActions>
+                                <BeginStoryboard>
+                                    <Storyboard>
+                                        <DoubleAnimation Storyboard.TargetName="ScrollThumb"
+                                                         Storyboard.TargetProperty="Width"
+                                                         To="2" Duration="0:0:0.18">
+                                            <DoubleAnimation.EasingFunction>
+                                                <QuadraticEase EasingMode="EaseOut"/>
+                                            </DoubleAnimation.EasingFunction>
+                                        </DoubleAnimation>
+                                    </Storyboard>
+                                </BeginStoryboard>
+                            </MultiTrigger.ExitActions>
+                        </MultiTrigger>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="Orientation" Value="Horizontal"/>
+                                <Condition Property="IsMouseOver" Value="True"/>
+                            </MultiTrigger.Conditions>
+                            <MultiTrigger.EnterActions>
+                                <BeginStoryboard>
+                                    <Storyboard>
+                                        <DoubleAnimation Storyboard.TargetName="ScrollThumb"
+                                                         Storyboard.TargetProperty="Height"
+                                                         To="4" Duration="0:0:0.12">
+                                            <DoubleAnimation.EasingFunction>
+                                                <QuadraticEase EasingMode="EaseOut"/>
+                                            </DoubleAnimation.EasingFunction>
+                                        </DoubleAnimation>
+                                    </Storyboard>
+                                </BeginStoryboard>
+                            </MultiTrigger.EnterActions>
+                            <MultiTrigger.ExitActions>
+                                <BeginStoryboard>
+                                    <Storyboard>
+                                        <DoubleAnimation Storyboard.TargetName="ScrollThumb"
+                                                         Storyboard.TargetProperty="Height"
+                                                         To="2" Duration="0:0:0.18">
+                                            <DoubleAnimation.EasingFunction>
+                                                <QuadraticEase EasingMode="EaseOut"/>
+                                            </DoubleAnimation.EasingFunction>
+                                        </DoubleAnimation>
+                                    </Storyboard>
+                                </BeginStoryboard>
+                            </MultiTrigger.ExitActions>
+                        </MultiTrigger>
                         <Trigger Property="IsEnabled" Value="False">
-                            <Setter Property="Opacity" Value="0.35"/>
+                            <Setter Property="Opacity" Value="0.28"/>
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -221,8 +247,7 @@
         <Style.Triggers>
             <Trigger Property="Orientation" Value="Horizontal">
                 <Setter Property="Width" Value="Auto"/>
-                <Setter Property="Height" Value="8"/>
-                <Setter Property="Margin" Value="0,2,0,0"/>
+                <Setter Property="Height" Value="6"/>
             </Trigger>
         </Style.Triggers>
     </Style>

--- a/src/SharedUI/Themes/DarkTheme.xaml
+++ b/src/SharedUI/Themes/DarkTheme.xaml
@@ -46,6 +46,7 @@
     <SolidColorBrush x:Key="PrimaryActionHoverBorderBrush" Color="#FFC4E1FF"/>
     <SolidColorBrush x:Key="PrimaryActionPressedBorderBrush" Color="#FF79BDF8"/>
     <SolidColorBrush x:Key="PrimaryActionTextBrush" Color="#FF0F1419"/>
+    <SolidColorBrush x:Key="AboutCheckUpdatesTextBrush" Color="#FF0F1419"/>
     <SolidColorBrush x:Key="PrimaryActionFocusBrush" Color="#FF0F1419"/>
     <SolidColorBrush x:Key="PrimaryActionDisabledBrush" Color="#FF3A3A3D"/>
     <SolidColorBrush x:Key="PrimaryActionDisabledTextBrush" Color="#FFB8B8BD"/>
@@ -101,10 +102,10 @@
     <SolidColorBrush x:Key="ComboItemSelectedBrush" Color="#28FFFFFF"/>
     <SolidColorBrush x:Key="ComboItemSelectedHoverBrush" Color="#38FFFFFF"/>
     <SolidColorBrush x:Key="ComboBorderHoverBrush" Color="#52FFFFFF"/>
-    <SolidColorBrush x:Key="ScrollTrackBrush" Color="#0FFFFFFF"/>
-    <SolidColorBrush x:Key="ScrollTrackHoverBrush" Color="#1AFFFFFF"/>
-    <SolidColorBrush x:Key="ScrollThumbBrush" Color="#52FFFFFF"/>
-    <SolidColorBrush x:Key="ScrollThumbHoverBrush" Color="#73FFFFFF"/>
+    <SolidColorBrush x:Key="ScrollTrackBrush" Color="#00FFFFFF"/>
+    <SolidColorBrush x:Key="ScrollTrackHoverBrush" Color="#24FFFFFF"/>
+    <SolidColorBrush x:Key="ScrollThumbBrush" Color="#70FFFFFF"/>
+    <SolidColorBrush x:Key="ScrollThumbHoverBrush" Color="#94FFFFFF"/>
     <SolidColorBrush x:Key="ScrollThumbPressedBrush" Color="#A6FFFFFF"/>
     <Color x:Key="CardShadowColor">#FF000000</Color>
 </ResourceDictionary>

--- a/src/SharedUI/Themes/LightTheme.xaml
+++ b/src/SharedUI/Themes/LightTheme.xaml
@@ -46,6 +46,7 @@
     <SolidColorBrush x:Key="PrimaryActionHoverBorderBrush" Color="#FF052D4F"/>
     <SolidColorBrush x:Key="PrimaryActionPressedBorderBrush" Color="#FF031D32"/>
     <SolidColorBrush x:Key="PrimaryActionTextBrush" Color="#FFFFFFFF"/>
+    <SolidColorBrush x:Key="AboutCheckUpdatesTextBrush" Color="#FFFFFFFF"/>
     <SolidColorBrush x:Key="PrimaryActionFocusBrush" Color="#FFFFFFFF"/>
     <SolidColorBrush x:Key="PrimaryActionDisabledBrush" Color="#FFE5E5E8"/>
     <SolidColorBrush x:Key="PrimaryActionDisabledTextBrush" Color="#FF59595D"/>
@@ -101,10 +102,10 @@
     <SolidColorBrush x:Key="ComboItemSelectedBrush" Color="#16000000"/>
     <SolidColorBrush x:Key="ComboItemSelectedHoverBrush" Color="#22000000"/>
     <SolidColorBrush x:Key="ComboBorderHoverBrush" Color="#52000000"/>
-    <SolidColorBrush x:Key="ScrollTrackBrush" Color="#0D000000"/>
-    <SolidColorBrush x:Key="ScrollTrackHoverBrush" Color="#14000000"/>
-    <SolidColorBrush x:Key="ScrollThumbBrush" Color="#52000000"/>
-    <SolidColorBrush x:Key="ScrollThumbHoverBrush" Color="#73000000"/>
+    <SolidColorBrush x:Key="ScrollTrackBrush" Color="#00000000"/>
+    <SolidColorBrush x:Key="ScrollTrackHoverBrush" Color="#1A000000"/>
+    <SolidColorBrush x:Key="ScrollThumbBrush" Color="#66000000"/>
+    <SolidColorBrush x:Key="ScrollThumbHoverBrush" Color="#85000000"/>
     <SolidColorBrush x:Key="ScrollThumbPressedBrush" Color="#A6000000"/>
     <Color x:Key="CardShadowColor">#FF000000</Color>
 </ResourceDictionary>


### PR DESCRIPTION
# iPhoneMirror UI polish and single-instance protection

## Summary

This change polishes the Windows 11 visual experience and prevents multiple
iPhoneMirror windows from competing for the same capture session. It keeps the
existing FluentWindow, NavigationView, Mica/Acrylic, Card, rounded-control,
theme, and animation architecture intact.

The Release artifacts below retain product version `1.5.7`. They are intended
as test candidates for this source change and must not replace the already
published GitHub `v1.5.7` assets without an explicit versioning decision.

## User-facing changes

### Scrollbars

- Replaced the shared WPF scrollbar appearance with a modern 6 px layout slot.
- The resting thumb is 2 px wide or tall and expands smoothly to 4 px on hover.
- The track stays visually transparent until hover, reducing visual noise.
- Light and dark themes use separate semantic brushes for thumb, hover,
  pressed, and track states.
- The settings scrollbar is offset 6 px to the right after visual tuning,
  while content keeps a 10 px reserve and remains clear of the rounded border.
- Vertical and horizontal orientations retain paging commands and minimum thumb
  sizes for usability.

### Single-instance startup

- Added a named per-session mutex for current builds.
- Added same-name, same-session process discovery for compatibility with older
  builds that do not own the mutex.
- Added a named shutdown event so a current secondary instance can request a
  graceful shutdown even while the primary window is still loading.
- Added a Fluent Acrylic conflict dialog with localized Chinese and English
  text, rounded surfaces, theme-aware colors, and an entrance transition.
- The secondary action closes the other window and continues the current
  launch. The more prominent right-side primary action closes the current
  window and leaves the active mirroring session untouched.
- Graceful close is attempted first. A bounded process-tree termination fallback
  is used only after the user explicitly chooses to close the other instance.

### About page

- The light-theme Check for updates action now has an explicit white
  foreground. The dark theme preserves the existing dark foreground chosen for
  its lighter accent surface.

## Review fixes and cleanup

- Fixed a simultaneous-launch race where the mutex owner could also detect a
  newer contender and show a second conflict dialog. A mutex-owning process now
  prompts only for an instance that started earlier.
- Replaced wall-clock close deadlines with `Stopwatch` so time adjustments
  cannot extend or shorten the shutdown workflow.
- Disposed process objects excluded during session and identity filtering.
- Treat inaccessible process state conservatively instead of reporting a false
  successful close.
- Disabled all close actions while the close-other operation is active, avoiding
  disposal races between the background shutdown operation and app exit.
- Added exception handling and diagnostic events for close failures.
- Fixed the CI-discovered media-output startup race by monitoring FFmpeg exit
  throughout the projection audio pipe handshake. A process that exits after
  the initial 350 ms observation window now reports its real startup failure
  instead of waiting for the 5 second pipe timeout.
- Replaced the timing-sensitive external-process test with a deterministic
  delayed-exit helper mode that reliably covers the audio-handshake window.
- Updated static UI contracts and runtime theme assertions for the new scrollbar
  dimensions, 6 px offset, Acrylic conflict dialog, and About button foreground.
- Added an Unreleased changelog entry.

## Validation

- `dotnet build src/App/iPhoneMirror.App.csproj -c Release --nologo`
  completed with 0 warnings and 0 errors.
- App logic tests passed.
- Real WPF runtime theme tests passed in light and dark modes.
- Driver installer tests, VC runtime version parser tests, and Apple support
  package validation tests passed.
- Native CTest suite passed 6 of 6 tests:
  CoreProtocolTests, OutputModeStateTests, WirelessHostSmoke,
  WirelessHostRuntimePreflight, WirelessHostInvalidImagePreflight, and
  VirtualCameraComponentTests.
- Full `build.ps1 -Configuration Release` completed successfully.
- GitHub Actions `Windows build / build-test` passed in 4 minutes 33 seconds
  after the media-output startup fix.
- Release packaging completed through Inno Setup 6.7.3.
- SPDX 2.2 SBOM generation completed successfully.
- `git diff --check` passed.
- Formatting verification passed for every changed C# production file.

## Release artifacts

| Artifact | Size | SHA-256 |
| --- | ---: | --- |
| `iPhoneMirror-Setup-v1.5.7-x64.exe` | 167,293,563 bytes | `a0291b0de1430f05c8c6811175cc6c357f5fc0559c0cc5d3528e02a418170cbf` |
| `iPhoneMirror-v1.5.7-win-x64.zip` | 187,996,645 bytes | `7fe3588435c3192b0d4611ca56ea004dd29c503fd1775e58927729df7524c3e6` |
| `iPhoneMirror-v1.5.7-win-x64-latest.zip` | 187,996,645 bytes | `7fe3588435c3192b0d4611ca56ea004dd29c503fd1775e58927729df7524c3e6` |
| `iPhoneMirror-v1.5.7-win-x64-sbom.spdx.json` | 67,531 bytes | `a76a238dbe1c6c79a57a529f464be9134235aba261eb5212c07baa20e4a76599` |

## Compatibility and risk

- No capture, decoding, audio, OBS output, virtual-camera, or driver protocol was
  changed.
- No user settings schema or runtime dependency was added.
- Single-instance discovery is limited to the current Windows session.
- The forced-close fallback is restricted to processes captured by the initial
  same-name, same-session scan and runs only after explicit user confirmation.
- The installer is not commercially Authenticode-signed, so Windows SmartScreen
  may show an unknown-publisher warning.
